### PR TITLE
Nuevas reglas para fontWeight y fontSize

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const allRules = {
   'no-unknown-theme-color': require('./lib/rules/no-unknown-theme-color'),
+  'no-unknown-theme-font-size': require('./lib/rules/no-unknown-theme-font-size'),
+  'no-unknown-theme-font-weight': require('./lib/rules/no-unknown-theme-font-weight'),
 }
 
 module.exports = {
@@ -15,6 +17,8 @@ module.exports = {
       plugins: ['theme-helpers'],
       rules: {
         'theme-helpers/no-unknown-theme-color': 2,
+        'theme-helpers/no-unknown-theme-font-size': 2,
+        'theme-helpers/no-unknown-theme-font-weight': 2,
       },
     },
   },

--- a/lib/rules/no-unknown-theme-color.js
+++ b/lib/rules/no-unknown-theme-color.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme color '{{name}}'"
 
-function isColorName({type, value}, {colors}) {
+function isColorName({type, value}, colors) {
   return colors.includes(value)
 }
 
@@ -11,7 +11,7 @@ module.exports = {
          if (node.callee.name === 'themeColor') {
           const [firstArgument] = node.arguments
           const [colors] = context.options
-          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, colors)) {
+          if (firstArgument.type === 'Literal' && colors.colors && !isColorName(firstArgument, colors.colors)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-color.js
+++ b/lib/rules/no-unknown-theme-color.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme color '{{name}}'"
 
-function isColorName({ type, value }, colors) {
+function isColorName({type, value}, {colors}) {
   return colors.includes(value)
 }
 
@@ -10,7 +10,8 @@ module.exports = {
       CallExpression(node) {
          if (node.callee.name === 'themeColor') {
           const [firstArgument] = node.arguments
-          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, context.options[0].colors)) {
+          const [colors] = context.options
+          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, colors)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-color.js
+++ b/lib/rules/no-unknown-theme-color.js
@@ -26,18 +26,19 @@ const COLOR_PROP_NAMES = [
   'darkFacebookBlue',
 ]
 
-function isColorName({ type, value }) {
-  return COLOR_PROP_NAMES.includes(value)
+function isColorName({ type, value, colors }) {
+  return colors.includes(value)
 }
 
 module.exports = {
   create: function(context) {
     return {
       CallExpression(node) {
+        console.log("Rule", {options: context.options[0].colors})
         if (node.callee.name === 'themeColor') {
           const [firstArgument] = node.arguments
 
-          if (firstArgument.type === 'Literal' && !isColorName(firstArgument)) {
+          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, context.options[0].colors)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-size.js
+++ b/lib/rules/no-unknown-theme-font-size.js
@@ -1,16 +1,16 @@
-const UNKNOWN_MESSAGE = "Unknown theme color '{{name}}'"
+const UNKNOWN_MESSAGE = "Unknown theme font size '{{name}}'"
 
-function isColorName({ type, value }, colors) {
-  return colors.includes(value)
+function isFontSizeValid({ type, value }, fontSizes) {
+  return fontSizes.includes(value)
 }
 
 module.exports = {
   create: function(context) {
     return {
       CallExpression(node) {
-         if (node.callee.name === 'themeColor') {
+         if (node.callee.name === 'themeFontSize') {
           const [firstArgument] = node.arguments
-          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, context.options[0].colors)) {
+          if (firstArgument.type === 'Literal' && !isFontSizeValid(firstArgument, context.options[0].fontSizes)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-size.js
+++ b/lib/rules/no-unknown-theme-font-size.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme font size '{{name}}'"
 
-function isFontSizeValid({type, value}, {fontSizes}) {
+function isFontSizeValid({type, value}, fontSizes) {
   return fontSizes.includes(value)
 }
 
@@ -11,7 +11,7 @@ module.exports = {
          if (node.callee.name === 'themeFontSize') {
           const [firstArgument] = node.arguments
           const [fontSizes] = context.fontSizes
-          if (firstArgument.type === 'Literal' && !isFontSizeValid(firstArgument, fontSizes)) {
+          if (firstArgument.type === 'Literal' && fontSizes.fontSizes && !isFontSizeValid(firstArgument, fontSizes.fontSizes)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-size.js
+++ b/lib/rules/no-unknown-theme-font-size.js
@@ -10,7 +10,7 @@ module.exports = {
       CallExpression(node) {
          if (node.callee.name === 'themeFontSize') {
           const [firstArgument] = node.arguments
-          const [fontSizes] = context.fontSizes
+          const [fontSizes] = context.options
           if (firstArgument.type === 'Literal' && fontSizes.fontSizes && !isFontSizeValid(firstArgument, fontSizes.fontSizes)) {
             context.report({
               node,

--- a/lib/rules/no-unknown-theme-font-size.js
+++ b/lib/rules/no-unknown-theme-font-size.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme font size '{{name}}'"
 
-function isFontSizeValid({ type, value }, fontSizes) {
+function isFontSizeValid({type, value}, {fontSizes}) {
   return fontSizes.includes(value)
 }
 
@@ -10,7 +10,8 @@ module.exports = {
       CallExpression(node) {
          if (node.callee.name === 'themeFontSize') {
           const [firstArgument] = node.arguments
-          if (firstArgument.type === 'Literal' && !isFontSizeValid(firstArgument, context.options[0].fontSizes)) {
+          const [fontSizes] = context.fontSizes
+          if (firstArgument.type === 'Literal' && !isFontSizeValid(firstArgument, fontSizes)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-weight.js
+++ b/lib/rules/no-unknown-theme-font-weight.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme font weight '{{name}}'"
 
-function isFontWeightValid({ type, value }, fontWeights) {
+function isFontWeightValid({ type, value }, {fontWeights}) {
   return fontWeights.includes(value)
 }
 
@@ -10,7 +10,8 @@ module.exports = {
       CallExpression(node) {
          if (node.callee.name === 'themeFontWeight') {
           const [firstArgument] = node.arguments
-          if (firstArgument.type === 'Literal' && !isFontWeightValid(firstArgument, context.options[0].fontWeights)) {
+          const [fontWeights] = context.fontWeight
+          if (firstArgument.type === 'Literal' && !isFontWeightValid(firstArgument, fontWeights)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-weight.js
+++ b/lib/rules/no-unknown-theme-font-weight.js
@@ -10,7 +10,7 @@ module.exports = {
       CallExpression(node) {
          if (node.callee.name === 'themeFontWeight') {
           const [firstArgument] = node.arguments
-          const [fontWeights] = context.fontWeight
+          const [fontWeights] = context.options
           if (firstArgument.type === 'Literal' && fontWeights.fontWeights && !isFontWeightValid(firstArgument, fontWeights.fontWeights)) {
             context.report({
               node,

--- a/lib/rules/no-unknown-theme-font-weight.js
+++ b/lib/rules/no-unknown-theme-font-weight.js
@@ -1,6 +1,6 @@
 const UNKNOWN_MESSAGE = "Unknown theme font weight '{{name}}'"
 
-function isFontWeightValid({ type, value }, {fontWeights}) {
+function isFontWeightValid({ type, value }, fontWeights) {
   return fontWeights.includes(value)
 }
 
@@ -11,7 +11,7 @@ module.exports = {
          if (node.callee.name === 'themeFontWeight') {
           const [firstArgument] = node.arguments
           const [fontWeights] = context.fontWeight
-          if (firstArgument.type === 'Literal' && !isFontWeightValid(firstArgument, fontWeights)) {
+          if (firstArgument.type === 'Literal' && fontWeights.fontWeights && !isFontWeightValid(firstArgument, fontWeights.fontWeights)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/lib/rules/no-unknown-theme-font-weight.js
+++ b/lib/rules/no-unknown-theme-font-weight.js
@@ -1,16 +1,16 @@
-const UNKNOWN_MESSAGE = "Unknown theme color '{{name}}'"
+const UNKNOWN_MESSAGE = "Unknown theme font weight '{{name}}'"
 
-function isColorName({ type, value }, colors) {
-  return colors.includes(value)
+function isFontWeightValid({ type, value }, fontWeights) {
+  return fontWeights.includes(value)
 }
 
 module.exports = {
   create: function(context) {
     return {
       CallExpression(node) {
-         if (node.callee.name === 'themeColor') {
+         if (node.callee.name === 'themeFontWeight') {
           const [firstArgument] = node.arguments
-          if (firstArgument.type === 'Literal' && !isColorName(firstArgument, context.options[0].colors)) {
+          if (firstArgument.type === 'Literal' && !isFontWeightValid(firstArgument, context.options[0].fontWeights)) {
             context.report({
               node,
               message: UNKNOWN_MESSAGE,

--- a/tests/lib/rules/no-unknown-theme-color.test.js
+++ b/tests/lib/rules/no-unknown-theme-color.test.js
@@ -15,6 +15,10 @@ ruleTester.run('no-unknown-theme-color', rule, {
       code: 'themeColor(colorName);',
       options: [{colors: fakeColors}]
     },
+    {
+      code: 'themeColor(colorName);',
+      options: []
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-unknown-theme-color.test.js
+++ b/tests/lib/rules/no-unknown-theme-color.test.js
@@ -1,20 +1,25 @@
 const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/no-unknown-theme-color')
 
+const fakeColors = ["darkGray"]
+
 const ruleTester = new RuleTester()
 
 ruleTester.run('no-unknown-theme-color', rule, {
   valid: [
     {
       code: "themeColor('darkGray');",
+      options: [{colors: fakeColors}]
     },
     {
       code: 'themeColor(colorName);',
+      options: [{colors: fakeColors}]
     },
   ],
   invalid: [
     {
       code: "themeColor('darGray');",
+      options: [{colors: fakeColors}],
       errors: [
         {
           message: "Unknown theme color 'darGray'",

--- a/tests/lib/rules/no-unknown-theme-font-size.test.js
+++ b/tests/lib/rules/no-unknown-theme-font-size.test.js
@@ -15,6 +15,10 @@ ruleTester.run('no-unknown-theme-color', rule, {
       code: 'themeFontSize(fontSize);',
       options: [{fontSizes: fakeFontSizes}]
     },
+    {
+      code: 'themeFontSize(fontSize);',
+      options: []
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-unknown-theme-font-size.test.js
+++ b/tests/lib/rules/no-unknown-theme-font-size.test.js
@@ -1,0 +1,30 @@
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-unknown-theme-font-size')
+
+const fakeFontSizes = ["large"]
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-unknown-theme-color', rule, {
+  valid: [
+    {
+      code: "themeFontSize('large');",
+      options: [{fontSizes: fakeFontSizes}]
+    },
+    {
+      code: 'themeFontSize(fontSize);',
+      options: [{fontSizes: fakeFontSizes}]
+    },
+  ],
+  invalid: [
+    {
+      code: "themeFontSize('fake_size');",
+      options: [{fontSizes: fakeFontSizes}],
+      errors: [
+        {
+          message: "Unknown theme font size 'fake_size'",
+        },
+      ],
+    },
+  ],
+})

--- a/tests/lib/rules/no-unknown-theme-font-weight.test.js
+++ b/tests/lib/rules/no-unknown-theme-font-weight.test.js
@@ -15,6 +15,10 @@ ruleTester.run('no-unknown-theme-color', rule, {
       code: 'themeFontWeight(fontSize);',
       options: [{fontWeights: fakeFontWeight}]
     },
+    {
+      code: 'themeFontSize(fontSize);',
+      options: []
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-unknown-theme-font-weight.test.js
+++ b/tests/lib/rules/no-unknown-theme-font-weight.test.js
@@ -1,0 +1,30 @@
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-unknown-theme-font-weight')
+
+const fakeFontWeight = ["medium"]
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-unknown-theme-color', rule, {
+  valid: [
+    {
+      code: "themeFontWeight('medium');",
+      options: [{fontWeights: fakeFontWeight}]
+    },
+    {
+      code: 'themeFontWeight(fontSize);',
+      options: [{fontWeights: fakeFontWeight}]
+    },
+  ],
+  invalid: [
+    {
+      code: "themeFontWeight('fake_weight');",
+      options: [{fontWeights: fakeFontWeight}],
+      errors: [
+        {
+          message: "Unknown theme font weight 'fake_weight'",
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Se han creado dos reglas nuevas que validan las funciones: `themeFontWeight` y `themeFontSize` ademas ahora en lugar de tener el listado de atributos válidos definido dentro de cada regla, se le pasa como parámetro desde el fichero de configuración de ESlint.